### PR TITLE
pwndoctor list audits, pwndoctor clone, and fixing typos/better help messages

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/strykethru/pwndoctor/pkg/pwndoctor"
+)
+
+var DestinationName string
+var cloneCmd = &cobra.Command{
+	Use:   "clone",
+	Short: "Clone an audit",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		pwndoctor.Init(PwnDocURL)
+		pwndoctor.AutoAuth()
+
+		var engagementList []string
+		if EngagementName == "" {
+			auditNames := pwndoctor.GetAuditNames()
+			for _, name := range auditNames {
+				fmt.Println(name)
+			}
+			fmt.Println("Please provide the engagement name(s) you would like to clone with -e")
+		}
+		if EngagementName != "" {
+			engagementList = append(engagementList, strings.Split(EngagementName, ",")...)
+			if DestinationName == "" {
+				fmt.Println("Please provide the destination audit name with -d")
+			}
+			if DestinationName != "" {
+				pwndoctor.DoClone(engagementList, DestinationName)
+			}
+		}
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(cloneCmd)
+	cloneCmd.Flags().StringVarP(&PwnDocURL, "url", "u", "", "PwnDoc-NG URL (i.e. https://127.0.0.1:8443)")
+	cloneCmd.Flags().StringVarP(&EngagementName, "engagement", "e", "", "Engagement Name")
+	cloneCmd.Flags().StringVarP(&DestinationName, "destination", "d", "", "Destination Audit Name")
+}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/strykethru/pwndoctor/pkg/pwndoctor"
-	"strings"
 )
 
 var EngagementName string
@@ -30,7 +31,7 @@ var exportCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(exportCmd)
-	exportCmd.Flags().StringVarP(&PwnDocURL, "url", "u", "", "PwnDoc-NG URL")
+	exportCmd.Flags().StringVarP(&PwnDocURL, "url", "u", "", "PwnDoc-NG URL (i.e. https://127.0.0.1:8443)")
 	exportCmd.Flags().StringVarP(&pwndocSSHHost, "ip", "i", "", "PwnDoc-NG SSH IP (for mongodb dump)")
 	exportCmd.Flags().StringVarP(&pwndocSSHUser, "user", "U", "ubuntu", "PwnDoc-NG SSH user (for mongodb dump)")
 	exportCmd.Flags().StringVarP(&EngagementName, "engagement", "e", "", "Engagement Name")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,52 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/strykethru/pwndoctor/pkg/pwndoctor"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "lists things in pwndoc",
+	Long:  `lists different things in pwndoc, such as: audits, vulnerabilities, findings`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var listAuditsCmd = &cobra.Command{
+	Use:   "audits",
+	Short: "lists audits in pwndoc",
+	Long:  `lists audits in pwndoc`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// fmt.Println("URL:", PwnDocURL)
+
+		pwndoctor.Init(PwnDocURL)
+		username, password, totp := pwndoctor.GetCredentialToken()
+		pwndoctor.Auth(username, password, totp)
+		auditNames := pwndoctor.GetAuditNames()
+		for _, name := range auditNames {
+			fmt.Println(name)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+	listCmd.AddCommand(listAuditsCmd)
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// listCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// listCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/populate.go
+++ b/cmd/populate.go
@@ -46,7 +46,7 @@ var csCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(csCmd)
 
-	csCmd.Flags().StringVarP(&PwnDocURL, "url", "u", "", "PwnDoc-NG URL")
+	csCmd.Flags().StringVarP(&PwnDocURL, "url", "u", "", "PwnDoc-NG URL (i.e https://127.0.0.1:8443)")
 	csCmd.Flags().BoolP("init", "i", false, "Create initial user")
 	//err := csCmd.MarkFlagRequired("region")
 	//if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "go-pwndoc",
+	Use:   "pwndoctor",
 	Short: "Go tool used with pwndoc",
 	Long: "Purpose: Populates Custom Sections and Fields\n" +
 		"If using KeepassXC, you can now pull your pwndoc credentials from your vault " +
@@ -40,7 +40,7 @@ func init() {
 	// will be global for your application.
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.go-pwndoc.yaml)")
-
+	rootCmd.PersistentFlags().StringVarP(&PwnDocURL, "url", "u", "", "PwnDoc-NG URL (i.e https://127.0.0.1:8443)")
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/pkg/pwndoc/api.go
+++ b/pkg/pwndoc/api.go
@@ -299,13 +299,32 @@ func (api *API) GetSettings() (*APIResponseSettings, error) {
 	return &exportedSettings, err
 }
 
-func (api *API) CreateAudit(auditName string, language string, auditType string) error {
+func (api *API) CreateAudit(auditName string, language string, auditType string) (*APIPostCreateAudits, error) {
 
 	body, err := api.PostResponseBody(PathAudits, bytes.NewReader([]byte(fmt.Sprintf(`{"name":"%s","language":"%s","auditType":"%s"}`, auditName, language, auditType))))
 	fmt.Println(string(body))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	var audit APIPostCreateAudits
+	err = json.Unmarshal(body, &audit)
+	return &audit, err
+}
+
+func (api *API) CreateFinding(auditID string, finding APIFindingDetails) error {
+	bodyReader, err := util.MarshalStuff(finding)
+
+	//not sure about body reader, make sure path is right
+	body, err := api.PostResponseBody(PathAudits+"/"+auditID+"/findings", bodyReader)
+	if err != nil {
+		return err
+
+	}
+	println("pls work")
+
+	print(string(body))
+	println()
+
+	return err
 }

--- a/pkg/pwndoc/api.go
+++ b/pkg/pwndoc/api.go
@@ -326,7 +326,6 @@ func (api *API) CreateNewFinding(auditID string, finding APIFindingDetails) erro
 	}
 
 	print(string(body))
-	println()
 
 	return err
 }
@@ -343,10 +342,8 @@ func (api *API) CreateNewSection(auditID string, section any, sectionID string) 
 		return err
 
 	}
-	println("pls work")
 
-	print(string(body))
-	println()
+	println(string(body))
 
 	return err
 }

--- a/pkg/pwndoc/api.go
+++ b/pkg/pwndoc/api.go
@@ -298,3 +298,14 @@ func (api *API) GetSettings() (*APIResponseSettings, error) {
 	err = json.Unmarshal(body, &exportedSettings)
 	return &exportedSettings, err
 }
+
+func (api *API) CreateAudit(auditName string, language string, auditType string) error {
+
+	body, err := api.PostResponseBody(PathAudits, bytes.NewReader([]byte(fmt.Sprintf(`{"name":"%s","language":"%s","auditType":"%s"}`, auditName, language, auditType))))
+	fmt.Println(string(body))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/pwndoc/api.go
+++ b/pkg/pwndoc/api.go
@@ -312,11 +312,33 @@ func (api *API) CreateAudit(auditName string, language string, auditType string)
 	return &audit, err
 }
 
-func (api *API) CreateFinding(auditID string, finding APIFindingDetails) error {
+func (api *API) CreateNewFinding(auditID string, finding APIFindingDetails) error {
 	bodyReader, err := util.MarshalStuff(finding)
+	if err != nil {
+		return err
+	}
 
 	//not sure about body reader, make sure path is right
 	body, err := api.PostResponseBody(PathAudits+"/"+auditID+"/findings", bodyReader)
+	if err != nil {
+		return err
+
+	}
+
+	print(string(body))
+	println()
+
+	return err
+}
+
+func (api *API) CreateNewSection(auditID string, section any, sectionID string) error {
+	bodyReader, err := util.MarshalStuff(section)
+	if err != nil {
+		return err
+	}
+
+	//not sure about body reader, make sure path is right
+	body, err := api.PutResponseBody(PathAudits+"/"+auditID+"/sections/"+sectionID, bodyReader)
 	if err != nil {
 		return err
 

--- a/pkg/pwndoc/structs.go
+++ b/pkg/pwndoc/structs.go
@@ -288,3 +288,9 @@ type APIResponseSettings struct {
 	Status string      `json:"status"`
 	Data   APISettings `json:"datas"`
 }
+
+type APICreateAudit struct {
+	Name      string `json:"name"`
+	Language  string `json:"language"`
+	AuditType string `json:"auditType"`
+}

--- a/pkg/pwndoc/structs.go
+++ b/pkg/pwndoc/structs.go
@@ -2,6 +2,7 @@ package pwndoc
 
 import (
 	"fmt"
+	"time"
 )
 
 type APILogin struct {
@@ -293,4 +294,55 @@ type APICreateAudit struct {
 	Name      string `json:"name"`
 	Language  string `json:"language"`
 	AuditType string `json:"auditType"`
+}
+
+type APIPostCreateAudits struct {
+	Status string `json:"status"`
+	Datas  struct {
+		Message string `json:"message"`
+		Audit   struct {
+			Name          string        `json:"name"`
+			AuditType     string        `json:"auditType"`
+			Collaborators []interface{} `json:"collaborators"`
+			Reviewers     []interface{} `json:"reviewers"`
+			Language      string        `json:"language"`
+			Template      string        `json:"template"`
+			Creator       string        `json:"creator"`
+			Sections      []struct {
+				Field        string `json:"field"`
+				Name         string `json:"name"`
+				CustomFields []struct {
+					CustomField struct {
+						ID          string        `json:"_id"`
+						FieldType   string        `json:"fieldType"`
+						Label       string        `json:"label"`
+						Display     string        `json:"display"`
+						DisplaySub  string        `json:"displaySub"`
+						Size        int           `json:"size"`
+						Offset      int           `json:"offset"`
+						Required    bool          `json:"required"`
+						Description string        `json:"description"`
+						Options     []interface{} `json:"options"`
+					} `json:"customField"`
+					Text string `json:"text"`
+				} `json:"customFields"`
+				ID string `json:"_id"`
+			} `json:"sections"`
+			CustomFields []interface{} `json:"customFields"`
+			SortFindings []struct {
+				Category  string `json:"category"`
+				SortValue string `json:"sortValue"`
+				SortOrder string `json:"sortOrder"`
+				SortAuto  bool   `json:"sortAuto"`
+			} `json:"sortFindings"`
+			State     string        `json:"state"`
+			Approvals []interface{} `json:"approvals"`
+			ID        string        `json:"_id"`
+			Scope     []interface{} `json:"scope"`
+			Findings  []interface{} `json:"findings"`
+			CreatedAt time.Time     `json:"createdAt"`
+			UpdatedAt time.Time     `json:"updatedAt"`
+			V         int           `json:"__v"`
+		} `json:"audit"`
+	} `json:"datas"`
 }

--- a/pkg/pwndoc/structs.go
+++ b/pkg/pwndoc/structs.go
@@ -346,3 +346,24 @@ type APIPostCreateAudits struct {
 		} `json:"audit"`
 	} `json:"datas"`
 }
+
+type APISectionPut struct {
+	Field        string `json:"field"`
+	Name         string `json:"name"`
+	CustomFields []struct {
+		CustomField struct {
+			ID          string        `json:"_id"`
+			FieldType   string        `json:"fieldType"`
+			Label       string        `json:"label"`
+			Display     string        `json:"display"`
+			DisplaySub  string        `json:"displaySub"`
+			Size        int           `json:"size"`
+			Offset      int           `json:"offset"`
+			Required    bool          `json:"required"`
+			Description string        `json:"description"`
+			Options     []interface{} `json:"options"`
+		} `json:"customField"`
+		Text string `json:"text"`
+	} `json:"customFields"`
+	ID string `json:"_id"`
+}

--- a/pkg/pwndoctor/clone.go
+++ b/pkg/pwndoctor/clone.go
@@ -94,6 +94,7 @@ func CloneAudit(audit pwndoc.APIAudit, destination string) error {
 		return err
 	}
 	createdauditid := createdaudit.Datas.Audit.ID
+
 	println("created audit ID = " + createdaudit.Datas.Audit.ID)
 
 	file, _ := json.MarshalIndent(retrievedAuditInformation, "", "  ")
@@ -103,6 +104,23 @@ func CloneAudit(audit pwndoc.APIAudit, destination string) error {
 		return err
 	}
 
+	// Create the custom sections YOLO
+	for a, section := range retrievedAuditInformation.Data.Sections {
+
+		// Create the section
+		// println("\n creating section, hold on to your butts")
+		// println("from: " + retrievedAuditInformation.Data.ID)
+		// println("to: " + createdauditid)
+		// println("section.ID = " + section.ID)
+		// println("section.Title = " + section.Name)
+		// fmt.Println(section)
+		fmt.Println("Creating section: \n\n", section)
+		println("section.ID = " + section.ID + "\n\n\n")
+		err = pwndocAPI.CreateNewSection(createdauditid, section, createdaudit.Datas.Audit.Sections[a].ID)
+		if err != nil {
+			return err
+		}
+	}
 	for _, finding := range retrievedAuditInformation.Data.Findings {
 
 		// Create the finding
@@ -113,7 +131,7 @@ func CloneAudit(audit pwndoc.APIAudit, destination string) error {
 		println("finding.Title = " + finding.Title)
 		println("finding.Description = " + finding.Description)
 		println("finding.Observation = " + finding.Observation)
-		err = pwndocAPI.CreateFinding(createdauditid, finding)
+		err = pwndocAPI.CreateNewFinding(createdauditid, finding)
 		if err != nil {
 			return err
 		}

--- a/pkg/pwndoctor/clone.go
+++ b/pkg/pwndoctor/clone.go
@@ -1,0 +1,191 @@
+package pwndoctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/strykethru/pwndoctor/pkg/pwndoc"
+)
+
+func DoClone(includeAuditNames []string, destination string) {
+
+	allAudits, err := pwndocAPI.GetAudits()
+	if err != nil {
+		fmt.Printf("Error getting audits from pwndoc: %s", err)
+	}
+
+	if len(includeAuditNames) == 0 {
+		retrievedAudits, err := pwndocAPI.GetAudits()
+		if err != nil {
+			log.Fatal("Error reading response body (AUDITS): ", err)
+		}
+
+		for _, data := range retrievedAudits.Data {
+
+			includeAuditNames = append(includeAuditNames, data.Name)
+		}
+	}
+
+	//////////////////////////////////////////////
+	// THIS IS WHERE WE GET CURRENT ENGAGEMENTS //
+	//////////////////////////////////////////////
+
+	for _, audit := range allAudits.Data {
+		if len(includeAuditNames) > 0 {
+			isAuditIncluded := false
+			for _, auditName := range includeAuditNames {
+				if audit.Name == auditName {
+					isAuditIncluded = true
+					break
+				}
+			}
+			if !isAuditIncluded {
+				fmt.Println("Skipping..." + audit.Name)
+				continue
+			}
+		}
+
+		fmt.Println("[+] Audit ID: ", audit.ID)
+		fmt.Println("[+] Exporting Audit info...")
+
+		dirList := []string{"audit-findings", "images", "report"}
+		for _, dir := range dirList {
+			newDir := fmt.Sprintf("exports/%s/%s", audit.Name, dir)
+			if _, err := os.Stat(newDir); os.IsNotExist(err) {
+				if err := os.MkdirAll(newDir, os.ModePerm); err != nil {
+					log.Fatal(err)
+				}
+			}
+		}
+
+		fmt.Printf("[+] Exporting Audit:(%s) Company:(%s)", audit.Name, audit.Company.Name)
+		err = CloneAudit(audit, destination)
+		if err != nil {
+			log.Fatal("[-] Error exporting audit response body (exporting audit): ", err)
+		}
+		fmt.Println("\n[+] Done exporting exporting audit info...")
+
+		// Import the Audit
+		//err = PostCloneAudit(audit)
+
+	}
+
+}
+
+func CloneAudit(audit pwndoc.APIAudit, destination string) error {
+
+	{
+		retrievedAuditInformation, err := pwndocAPI.GetAudit(audit.ID)
+		if err != nil {
+			return err
+		}
+
+		file, _ := json.MarshalIndent(retrievedAuditInformation, "", "  ")
+		fileName := fmt.Sprintf("exports/%s/audit-findings/OG-%s-finding.json", audit.Name, retrievedAuditInformation.Data.ID)
+		err = os.WriteFile(fileName, file, 0644)
+		if err != nil {
+			return err
+		}
+
+		for _, finding := range retrievedAuditInformation.Data.Findings {
+			file, err := json.MarshalIndent(finding, "", "  ")
+			if err != nil {
+				return err
+			}
+			fileName := fmt.Sprintf("exports/%s/audit-findings/%s-finding.json", audit.Name, finding.ID)
+			err = os.WriteFile(fileName, file, 0644)
+			if err != nil {
+				return err
+			}
+
+			err = pwndoc.DownloadImagesInContent(finding.Description, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+			if err != nil {
+				return err
+			}
+			err = pwndoc.DownloadImagesInContent(finding.Observation, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+			if err != nil {
+				return err
+			}
+			err = pwndoc.DownloadImagesInContent(finding.Poc, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+			if err != nil {
+				return err
+			}
+			err = pwndoc.DownloadImagesInContent(finding.AffectedAssets, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+			if err != nil {
+				return err
+			}
+			err = pwndoc.DownloadImagesInContent(finding.Remediation, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+			if err != nil {
+				return err
+			}
+		}
+
+		println("\n importing audit")
+		lang := retrievedAuditInformation.Data.Language
+		println("lang =" + lang)
+		auditType := retrievedAuditInformation.Data.AuditType
+		println("auditType =" + auditType)
+
+		err = pwndocAPI.CreateAudit(destination, lang, auditType)
+		if err != nil {
+			return err
+		}
+
+		return nil
+
+	}
+}
+
+// func PostCloneAudit(audit pwndoc.APIAudit) error {
+
+// 	{
+// 		retrievedAuditInformation, err := pwndocAPI.GetAudit(audit.ID)
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		file, _ := json.MarshalIndent(retrievedAuditInformation, "", "  ")
+// 		fileName := fmt.Sprintf("exports/%s/audit-findings/OG-%s-finding.json", audit.Name, retrievedAuditInformation.Data.ID)
+// 		err = os.WriteFile(fileName, file, 0644)
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		for _, finding := range retrievedAuditInformation.Data.Findings {
+// 			file, err := json.MarshalIndent(finding, "", "  ")
+// 			if err != nil {
+// 				return err
+// 			}
+// 			fileName := fmt.Sprintf("exports/%s/audit-findings/%s-finding.json", audit.Name, finding.ID)
+// 			err = os.WriteFile(fileName, file, 0644)
+// 			if err != nil {
+// 				return err
+// 			}
+
+// 			err = pwndoc.DownloadImagesInContent(finding.Description, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+// 			if err != nil {
+// 				return err
+// 			}
+// 			err = pwndoc.DownloadImagesInContent(finding.Observation, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+// 			if err != nil {
+// 				return err
+// 			}
+// 			err = pwndoc.DownloadImagesInContent(finding.Poc, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+// 			if err != nil {
+// 				return err
+// 			}
+// 			err = pwndoc.DownloadImagesInContent(finding.AffectedAssets, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+// 			if err != nil {
+// 				return err
+// 			}
+// 			err = pwndoc.DownloadImagesInContent(finding.Remediation, pwndocAPI.Token, pwndocAPI.HTTPClient, audit.Name)
+// 			if err != nil {
+// 				return err
+// 			}
+// 		}
+
+// 		return nil
+// 	}
+// }

--- a/pkg/pwndoctor/helpers.go
+++ b/pkg/pwndoctor/helpers.go
@@ -377,3 +377,16 @@ func CreateSettings() {
 	}
 	fmt.Println("[+] Done Importing APISettings!")
 }
+
+func GetAuditNames() []string {
+	audits, err := pwndocAPI.GetAudits()
+	if err != nil {
+		log.Fatalf("Error getting audits: %s", err)
+	}
+
+	var auditNames []string
+	for _, audit := range audits.Data {
+		auditNames = append(auditNames, audit.Name)
+	}
+	return auditNames
+}

--- a/pkg/pwndoctor/helpers.go
+++ b/pkg/pwndoctor/helpers.go
@@ -377,29 +377,3 @@ func CreateSettings() {
 	}
 	fmt.Println("[+] Done Importing APISettings!")
 }
-
-func GetAuditNames() []string {
-	audits, err := pwndocAPI.GetAudits()
-	if err != nil {
-		log.Fatalf("Error getting audits: %s", err)
-	}
-
-	var auditNames []string
-	for _, audit := range audits.Data {
-		auditNames = append(auditNames, audit.Name)
-	}
-	return auditNames
-}
-
-// func CreateAudit(newAuditName string, auditLanguage string, auditType string) {
-// 	// audit := pwndoc.APICreateAudit{
-// 	// 	Name:    newAuditName,
-// 	// 	Language: auditLanguage,
-// 	// 	AuditType: auditType,
-// 	// }
-
-// 	_, err := pwndocAPI.CreateAudit(audit)
-// 	if err != nil {
-// 		log.Fatalf("Error creating audit: %s", err)
-// 	}
-// }

--- a/pkg/pwndoctor/helpers.go
+++ b/pkg/pwndoctor/helpers.go
@@ -390,3 +390,16 @@ func GetAuditNames() []string {
 	}
 	return auditNames
 }
+
+// func CreateAudit(newAuditName string, auditLanguage string, auditType string) {
+// 	// audit := pwndoc.APICreateAudit{
+// 	// 	Name:    newAuditName,
+// 	// 	Language: auditLanguage,
+// 	// 	AuditType: auditType,
+// 	// }
+
+// 	_, err := pwndocAPI.CreateAudit(audit)
+// 	if err != nil {
+// 		log.Fatalf("Error creating audit: %s", err)
+// 	}
+// }

--- a/pkg/pwndoctor/helpers.go
+++ b/pkg/pwndoctor/helpers.go
@@ -390,16 +390,3 @@ func GetAuditNames() []string {
 	}
 	return auditNames
 }
-
-// func CreateAudit(newAuditName string, auditLanguage string, auditType string) {
-// 	// audit := pwndoc.APICreateAudit{
-// 	// 	Name:    newAuditName,
-// 	// 	Language: auditLanguage,
-// 	// 	AuditType: auditType,
-// 	// }
-
-// 	_, err := pwndocAPI.CreateAudit(audit)
-// 	if err != nil {
-// 		log.Fatalf("Error creating audit: %s", err)
-// 	}
-// }

--- a/pkg/pwndoctor/helpers.go
+++ b/pkg/pwndoctor/helpers.go
@@ -377,16 +377,3 @@ func CreateSettings() {
 	}
 	fmt.Println("[+] Done Importing APISettings!")
 }
-
-func GetAuditNames() []string {
-	audits, err := pwndocAPI.GetAudits()
-	if err != nil {
-		log.Fatalf("Error getting audits: %s", err)
-	}
-
-	var auditNames []string
-	for _, audit := range audits.Data {
-		auditNames = append(auditNames, audit.Name)
-	}
-	return auditNames
-}


### PR DESCRIPTION
- adds `pwndoctor list audits` to list audits, lays the groundwork to list other things
- adds `pwndoctor clone` to clone audits
- makes the `-u` flag help more helpful by showing format the flag should be in
- usage said `go-pwndoc` instead of `pwndoctor`