### PR TITLE
Added functionality to export pwndoc finding data as a .csv file.

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -10,22 +10,29 @@ import (
 var EngagementName string
 var pwndocSSHHost string
 var pwndocSSHUser string
+var findingsDir string
 
 var exportCmd = &cobra.Command{
 	Use:   "export",
 	Short: "Do all the things to close up PwnDoc after engagement.",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		pwndoctor.Init(PwnDocURL)
-		pwndoctor.AutoAuth()
 
-		var engagementList []string
+		if findingsDir != "" {
+			pwndoctor.ExportCSVLocally(findingsDir)
+		} else {
+			pwndoctor.Init(PwnDocURL)
+			pwndoctor.AutoAuth()
 
-		if EngagementName != "" {
-			engagementList = append(engagementList, strings.Split(EngagementName, ",")...)
+			var engagementList []string
+
+			if EngagementName != "" {
+				engagementList = append(engagementList, strings.Split(EngagementName, ",")...)
+			}
+
+			pwndoctor.DoExport(engagementList, pwndocSSHUser, pwndocSSHHost)
 		}
 
-		pwndoctor.DoExport(engagementList, pwndocSSHUser, pwndocSSHHost)
 	},
 }
 
@@ -35,4 +42,5 @@ func init() {
 	exportCmd.Flags().StringVarP(&pwndocSSHHost, "ip", "i", "", "PwnDoc-NG SSH IP (for mongodb dump)")
 	exportCmd.Flags().StringVarP(&pwndocSSHUser, "user", "U", "ubuntu", "PwnDoc-NG SSH user (for mongodb dump)")
 	exportCmd.Flags().StringVarP(&EngagementName, "engagement", "e", "", "Engagement Name")
+	exportCmd.Flags().StringVarP(&findingsDir, "findingsDir", "f", "", "Directory of JSON files from an old PwnDoc/Report Archive (i.e. /path/to/JSON/Findings)")
 }

--- a/pkg/pwndoc/http.go
+++ b/pkg/pwndoc/http.go
@@ -5,11 +5,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/color"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/fatih/color"
 )
 
 var URL string

--- a/pkg/pwndoc/structs.go
+++ b/pkg/pwndoc/structs.go
@@ -204,6 +204,29 @@ type APIResponseLogin struct {
 	} `json:"datas"`
 }
 
+type APIFindingsDetailsOldReports struct {
+	Title               string  `json:"title,omitempty"`
+	Criticality         string  `json:"criticality,omitempty"`
+	Attack_Surface      string  `json:"attack_surface,omitempty"`
+	Type                string  `json:"type,omitempty"`
+	Description         string  `json:"description,omitempty"`
+	Mitre_Attack        string  `json:"mitre_attack,omitempty"`
+	Count               int     `json:"count,omitempty"`
+	CVSS_Score          float32 `json:"cvss_score,omitempty"`
+	CVSS_String         string  `json:"cvss_string,omitempty"`
+	Affected_Assets     string  `json:"affected_assets,omitempty"`
+	Evidence            string  `json:"evidence,omitempty"`
+	Detection           string  `json:"detection,omitempty"`
+	Summary             string  `json:"summary,omitempty"`
+	Recommendations     string  `json:"recommendations,omitempty"`
+	References          string  `json:"references,omitempty"`
+	Reviewed            bool    `json:"reviewed,omitempty"`
+	Resource_Identifier string  `json:"resource_identifier,omitempty"`
+	Created_Date        string  `json:"created_date,omitempty"`
+	Updated_Date        string  `json:"updated_date,omitempty"`
+	External_UUID       string  `json:"external_uuid,omitempty"`
+}
+
 type APIFindingDetails struct {
 	Identifier            int      `json:"identifier,omitempty"`
 	Title                 string   `json:"title,omitempty"`

--- a/pkg/pwndoctor/export.go
+++ b/pkg/pwndoctor/export.go
@@ -1,13 +1,17 @@
 package pwndoctor
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/strykethru/pwndoctor/pkg/pwndoc"
 )
@@ -137,6 +141,51 @@ func ExportAudit(audit pwndoc.APIAudit) error {
 		return err
 	}
 
+	////////////////////////////////////////////////////////
+	// THIS IS WHERE VULNERABILITIESDATA.CSV GETS CREATED //
+	////////////////////////////////////////////////////////
+	fileCSVPath := fmt.Sprintf("exports/%s/audit-findings/%s-vulnerabilitiesData.csv", audit.Name, audit.Name)
+	fileCSV, err := os.Create(fileCSVPath)
+	if err != nil {
+		return err
+	}
+	defer fileCSV.Close()
+
+	writer := csv.NewWriter(fileCSV)
+	defer writer.Flush()
+
+	// Write CSV header
+	writer.Write([]string{"Identifier", "Title", "Risk Rating", "VulnType", "Description", "Observation", "Remediation", "RemediationComplexity", "Priority", "CVSSv3", "Status", "Category"})
+
+	// Write data rows
+	for _, vuln := range retrievedAuditInformation.Data.Findings {
+		for _, field := range vuln.CustomFields {
+			if field.CustomField.Label == "risk_rating" {
+				vuln.Criticality = field.Text
+			} else {
+				vuln.Criticality = "Unknown"
+			}
+		}
+
+		row := []string{
+			strconv.Itoa(vuln.Identifier),
+			vuln.Title,
+			vuln.Criticality,
+			vuln.VulnType,
+			vuln.Description,
+			vuln.Observation,
+			vuln.Remediation,
+			strconv.Itoa(vuln.RemediationComplexity),
+			strconv.Itoa(vuln.Priority),
+			vuln.CVSSv3,
+			strconv.Itoa(vuln.Status),
+			vuln.Category,
+		}
+		writer.Write(row)
+	}
+
+	fmt.Println("CSV export complete: vulnerabilitiesData.csv")
+
 	for _, finding := range retrievedAuditInformation.Data.Findings {
 		file, err := json.MarshalIndent(finding, "", "  ")
 		if err != nil {
@@ -168,6 +217,68 @@ func ExportAudit(audit pwndoc.APIAudit) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func ExportCSVLocally(findingsDir string) error {
+
+	var vulnCounter = 0
+
+	//Creating CSV File
+	fileCSVPath := fmt.Sprintf("%s/vulnerabilitiesData.csv", findingsDir)
+	fileCSV, err := os.Create(fileCSVPath)
+	if err != nil {
+		return err
+	}
+	defer fileCSV.Close()
+
+	writer := csv.NewWriter(fileCSV)
+	defer writer.Flush()
+
+	// Write CSV header
+	writer.Write([]string{"Identifier", "Title", "Risk Rating", "VulnType", "Description", "Observation", "Remediation", "RemediationComplexity", "Priority", "CVSSv3", "Status", "Category"})
+
+	entries, err := os.ReadDir(findingsDir)
+	if err != nil {
+		fmt.Printf("Failed to read directory: %v\n", err)
+		return err
+	}
+
+	for _, entry := range entries {
+
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") || strings.HasPrefix(entry.Name(), "OG-") {
+			continue
+		}
+
+		filePath := filepath.Join(findingsDir, entry.Name())
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			continue
+		}
+
+		var vuln pwndoc.APIFindingsDetailsOldReports
+		if err := json.Unmarshal(content, &vuln); err != nil {
+			fmt.Printf("Failed to unmarshal JSON in %s: %v\n", filePath, err)
+			continue
+		}
+		vulnCounter++
+		row := []string{
+			strconv.Itoa(vulnCounter),
+			vuln.Title,
+			vuln.Criticality,
+			"N/A",
+			vuln.Summary,
+			vuln.Description,
+			vuln.Recommendations,
+			"N/A",
+			"N/A",
+			vuln.CVSS_String,
+			strconv.Itoa(vuln.Count),
+			vuln.Attack_Surface,
+		}
+		writer.Write(row)
 	}
 
 	return nil


### PR DESCRIPTION
Added functionality to export pwndoc finding data as a .csv file. This can be done 2 different ways. The first way occurs when you connect to the pwndoc instance and log in. The CSV file gets created in the ExportAudit function. The second instance is for when you are working with an old pwnDoc archive and the export already took place i.e. Report is no longer in PwnDoc. This requires the --findingsDir/-f flag and you have to specify the directory path to where the .json finding files are located. This method does not require authentication to the main pwndoc instance itself. This functionality is described in ExportCSVLocally method and will loop through the .json files and write the data to the .csv file. Export.go was modified to accodate this functionality and structs.go was modified to create a new finding struct since old reports don't have the same .json format.