### PR TITLE
Modified pwndoctor to be able to import findings

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,57 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/strykethru/pwndoctor/pkg/pwndoctor"
+)
+
+// importCmd represents the import command
+var importCmd = &cobra.Command{
+	Use:   "import",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("[+] Import called")
+
+		pwndoctor.Init(PwnDocURL)
+		pwndoctor.AutoAuth()
+
+		var engagementList []string
+
+		if EngagementName != "" {
+			engagementList = append(engagementList, strings.Split(EngagementName, ",")...)
+			if len(engagementList) > 1 {
+				fmt.Println("\n[!] Alert: You are attempting to import findings to multiple reports. Aborting out of caution")
+				os.Exit(1)
+			}
+		} else {
+			fmt.Println("[!] Alert: You must supply one and only one engagement name! Aborting.")
+			os.Exit(1)
+		}
+
+		pwndoctor.DoImport(EngagementName, findingsDir)
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(importCmd)
+	importCmd.Flags().StringVarP(&PwnDocURL, "url", "u", "", "PwnDoc-NG URL (i.e. https://127.0.0.1:8443)")
+	importCmd.Flags().StringVarP(&pwndocSSHHost, "ip", "i", "", "PwnDoc-NG SSH IP (for mongodb dump)")
+	importCmd.Flags().StringVarP(&pwndocSSHUser, "user", "U", "ubuntu", "PwnDoc-NG SSH user (for mongodb dump)")
+	importCmd.Flags().StringVarP(&EngagementName, "engagement", "e", "", "Engagment where you want to input the findings.")
+	importCmd.Flags().StringVarP(&findingsDir, "engDir", "f", "", "Directory of PwnDoc engagement directory (i.e. /path/to/engagement/directory)")
+
+}

--- a/pkg/pwndoc/api.go
+++ b/pkg/pwndoc/api.go
@@ -142,6 +142,13 @@ func (api *API) GetAudit(auditID string) (*APIResponseAudit, error) {
 	return &retrievedAuditInformation, err
 }
 
+func (api *API) InsertFinding(auditID string, byteData *bytes.Reader) ([]byte, error) {
+	insertPath := path.Join(PathAudits, auditID, "findings")
+	postResponse, err := api.PostResponseBody(insertPath, byteData)
+	//fmt.Println("[+] POST Response is %s", string(postResponse))
+	return postResponse, err
+}
+
 func (api *API) CreateReportTemplate(docName, docExt string, templateFile *os.File) (bool, error) {
 
 	// Read entire docx into byte slice

--- a/pkg/pwndoc/http.go
+++ b/pkg/pwndoc/http.go
@@ -78,8 +78,8 @@ func MakePostRequest(url string, bodyReader *bytes.Reader, token string, client 
 		return nil, err
 	}
 
-	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Cookie", token)
 
 	resp, err := client.Do(req)

--- a/pkg/pwndoctor/import.go
+++ b/pkg/pwndoctor/import.go
@@ -1,0 +1,77 @@
+package pwndoctor
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func DoImport(auditName string, findingsDir string) {
+	allAudits, err := pwndocAPI.GetAudits()
+	if err != nil {
+		fmt.Printf("Error getting audits from pwndoc: %s", err)
+	}
+
+	auditExists := false
+	var auditID string
+	for _, audit := range allAudits.Data {
+		if audit.Name == auditName {
+			auditExists = true
+			auditID = audit.ID
+			break
+		}
+	}
+
+	if !auditExists {
+		fmt.Printf("[!] Error: Audit %s not found in Pwndoc! Please enter a valid audit name and try again", auditName)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\n[+] Audit found in PwnDoc! Importing findings from %s into audit %s", findingsDir, auditName)
+	err = ImportFindings(auditID, findingsDir)
+	if err != nil {
+		log.Fatal("[-] Error import audit response body (import audit): ", err)
+	}
+	fmt.Println("\n[+] Done importing audit info...")
+	fmt.Println("\n[+] Done importing audit info...")
+
+}
+
+func ImportFindings(auditID string, findingsDir string) error {
+	auditFilePath := filepath.Join(findingsDir, "audit-findings")
+	files, err := os.ReadDir(auditFilePath)
+	if err != nil {
+		fmt.Println("Error reading directory:", err)
+		os.Exit(1)
+	}
+
+	//Only selecting entries that are JSON files
+	var fileNames []string
+	for _, file := range files {
+		if !file.IsDir() && filepath.Ext(file.Name()) == ".json" {
+			fileNames = append(fileNames, filepath.Join(auditFilePath, file.Name()))
+		}
+	}
+
+	for _, finding := range fileNames {
+		data, err := os.ReadFile(finding)
+		if err != nil {
+			fmt.Printf("Failed to read file %s: %v\n", finding, err)
+			continue
+		}
+
+		byteData := bytes.NewReader(data)
+
+		APIPostResponse, err := pwndocAPI.InsertFinding(auditID, byteData)
+		if err != nil {
+			fmt.Printf("\n[-] Error: An issue occurred inserting the finding %s: %v\n", finding, err)
+			break
+		}
+		fmt.Printf("\n[+] POST Response is %s", string(APIPostResponse))
+
+	}
+	return nil
+
+}


### PR DESCRIPTION
Modified pwndoctor to import findings from different audits. this is helpful for moving findings between reports. the reports must be exported before they can be imported. 